### PR TITLE
Better support for string conversions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Converters/issues/76
+Your prepared branch: issue-76-2ce7e576
+Your prepared working directory: /tmp/gh-issue-solver-1757730640414
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Converters/issues/76
-Your prepared branch: issue-76-2ce7e576
-Your prepared working directory: /tmp/gh-issue-solver-1757730640414
-
-Proceed.

--- a/cpp/Platform.Converters.Tests/Platform.Converters.Tests.cpp
+++ b/cpp/Platform.Converters.Tests/Platform.Converters.Tests.cpp
@@ -56,4 +56,86 @@ namespace Platform::Converters::Tests
 	    ASSERT_EQ(std::string("A"), To<std::string>(aReference));
 	    ASSERT_EQ(std::string("void pointer <0xa>"), To<std::string>((void *)10));
 	};
+
+	TEST(StringConverterTests, U8StringToStringConversion)
+	{
+	    std::u8string u8str = u8"Hello World";
+	    std::string result = To<std::string>(u8str);
+	    ASSERT_EQ(std::string("Hello World"), result);
+	    
+	    // Test UTF-8 characters
+	    std::u8string u8utf = u8"Привет мир";
+	    std::string resultUtf = To<std::string>(u8utf);
+	    ASSERT_EQ(std::string("Привет мир"), resultUtf);
+	};
+
+	TEST(StringConverterTests, StringToU8StringConversion)
+	{
+	    std::string str = "Hello World";
+	    std::u8string result = To<std::u8string>(str);
+	    ASSERT_EQ(u8"Hello World", result);
+	    
+	    // Test UTF-8 characters
+	    std::string strUtf = "Привет мир";
+	    std::u8string resultUtf = To<std::u8string>(strUtf);
+	    ASSERT_EQ(u8"Привет мир", resultUtf);
+	};
+
+	TEST(StringConverterTests, U16StringToU8StringConversion)
+	{
+	    std::u16string u16str = u"Hello World";
+	    std::u8string result = To<std::u8string>(u16str);
+	    ASSERT_EQ(u8"Hello World", result);
+	    
+	    // Test Unicode characters
+	    std::u16string u16unicode = u"Héllo Wörld";
+	    std::u8string resultUnicode = To<std::u8string>(u16unicode);
+	    ASSERT_EQ(u8"Héllo Wörld", resultUnicode);
+	};
+
+	TEST(StringConverterTests, U32StringToU8StringConversion)
+	{
+	    std::u32string u32str = U"Hello World";
+	    std::u8string result = To<std::u8string>(u32str);
+	    ASSERT_EQ(u8"Hello World", result);
+	    
+	    // Test Unicode characters
+	    std::u32string u32unicode = U"Héllo Wörld";
+	    std::u8string resultUnicode = To<std::u8string>(u32unicode);
+	    ASSERT_EQ(u8"Héllo Wörld", resultUnicode);
+	    
+	    // Test emoji (4-byte UTF-8)
+	    std::u32string u32emoji = U"Hello 🌍";
+	    std::u8string resultEmoji = To<std::u8string>(u32emoji);
+	    ASSERT_EQ(u8"Hello 🌍", resultEmoji);
+	};
+
+	TEST(StringConverterTests, U16StringToStringConversion)
+	{
+	    std::u16string u16str = u"Hello World";
+	    std::string result = To<std::string>(u16str);
+	    ASSERT_EQ(std::string("Hello World"), result);
+	    
+	    // Test Unicode characters
+	    std::u16string u16unicode = u"Héllo Wörld";
+	    std::string resultUnicode = To<std::string>(u16unicode);
+	    ASSERT_EQ(std::string("Héllo Wörld"), resultUnicode);
+	};
+
+	TEST(StringConverterTests, U32StringToStringConversion)
+	{
+	    std::u32string u32str = U"Hello World";
+	    std::string result = To<std::string>(u32str);
+	    ASSERT_EQ(std::string("Hello World"), result);
+	    
+	    // Test Unicode characters
+	    std::u32string u32unicode = U"Héllo Wörld";
+	    std::string resultUnicode = To<std::string>(u32unicode);
+	    ASSERT_EQ(std::string("Héllo Wörld"), resultUnicode);
+	    
+	    // Test emoji (4-byte UTF-8)
+	    std::u32string u32emoji = U"Hello 🌍";
+	    std::string resultEmoji = To<std::string>(u32emoji);
+	    ASSERT_EQ(std::string("Hello 🌍"), resultEmoji);
+	};
 }

--- a/cpp/Platform.Converters/StringConverter.h
+++ b/cpp/Platform.Converters/StringConverter.h
@@ -77,4 +77,108 @@ namespace Platform::Converters
             return to_string(std::forward<decltype(source)>(source));
         }
     };
+
+    // Specialized converters for UTF string types
+    template<>
+    struct Converter<std::u8string, std::string>
+    {
+        static std::string Convert(const std::u8string& source)
+        {
+            return std::string(reinterpret_cast<const char*>(source.c_str()), source.size());
+        }
+    };
+
+    template<>
+    struct Converter<std::string, std::u8string>
+    {
+        static std::u8string Convert(const std::string& source)
+        {
+            return std::u8string(reinterpret_cast<const char8_t*>(source.c_str()), source.size());
+        }
+    };
+
+    template<>
+    struct Converter<std::u16string, std::u8string>
+    {
+        static std::u8string Convert(const std::u16string& source)
+        {
+            std::u8string result;
+            for (char16_t ch : source)
+            {
+                if (ch < 0x80)
+                {
+                    result.push_back(static_cast<char8_t>(ch));
+                }
+                else if (ch < 0x800)
+                {
+                    result.push_back(static_cast<char8_t>(0xC0 | (ch >> 6)));
+                    result.push_back(static_cast<char8_t>(0x80 | (ch & 0x3F)));
+                }
+                else
+                {
+                    result.push_back(static_cast<char8_t>(0xE0 | (ch >> 12)));
+                    result.push_back(static_cast<char8_t>(0x80 | ((ch >> 6) & 0x3F)));
+                    result.push_back(static_cast<char8_t>(0x80 | (ch & 0x3F)));
+                }
+            }
+            return result;
+        }
+    };
+
+    template<>
+    struct Converter<std::u32string, std::u8string>
+    {
+        static std::u8string Convert(const std::u32string& source)
+        {
+            std::u8string result;
+            for (char32_t ch : source)
+            {
+                if (ch < 0x80)
+                {
+                    result.push_back(static_cast<char8_t>(ch));
+                }
+                else if (ch < 0x800)
+                {
+                    result.push_back(static_cast<char8_t>(0xC0 | (ch >> 6)));
+                    result.push_back(static_cast<char8_t>(0x80 | (ch & 0x3F)));
+                }
+                else if (ch < 0x10000)
+                {
+                    result.push_back(static_cast<char8_t>(0xE0 | (ch >> 12)));
+                    result.push_back(static_cast<char8_t>(0x80 | ((ch >> 6) & 0x3F)));
+                    result.push_back(static_cast<char8_t>(0x80 | (ch & 0x3F)));
+                }
+                else if (ch < 0x110000)
+                {
+                    result.push_back(static_cast<char8_t>(0xF0 | (ch >> 18)));
+                    result.push_back(static_cast<char8_t>(0x80 | ((ch >> 12) & 0x3F)));
+                    result.push_back(static_cast<char8_t>(0x80 | ((ch >> 6) & 0x3F)));
+                    result.push_back(static_cast<char8_t>(0x80 | (ch & 0x3F)));
+                }
+            }
+            return result;
+        }
+    };
+
+    // Chain conversions: u16string -> u8string -> string
+    template<>
+    struct Converter<std::u16string, std::string>
+    {
+        static std::string Convert(const std::u16string& source)
+        {
+            auto u8str = Converter<std::u16string, std::u8string>::Convert(source);
+            return Converter<std::u8string, std::string>::Convert(u8str);
+        }
+    };
+
+    // Chain conversions: u32string -> u8string -> string
+    template<>
+    struct Converter<std::u32string, std::string>
+    {
+        static std::string Convert(const std::u32string& source)
+        {
+            auto u8str = Converter<std::u32string, std::u8string>::Convert(source);
+            return Converter<std::u8string, std::string>::Convert(u8str);
+        }
+    };
 }


### PR DESCRIPTION
## Summary

This PR implements better support for string conversions as requested in issue #76. The implementation adds specialized converters for UTF string types while maintaining backward compatibility.

### ✨ Features Added

- **Bidirectional conversion between `std::u8string` and `std::string`**
  - Direct memory reinterpretation for efficient conversion
  - Assumes UTF-8 encoding for `std::string` (as per issue requirements)

- **Chain conversions for UTF-16 and UTF-32 strings**
  - `std::u16string` → `std::u8string` → `std::string`
  - `std::u32string` → `std::u8string` → `std::string`
  - Proper UTF-8 encoding for multi-byte characters

- **Comprehensive UTF-8 encoding support**
  - Handles 1-byte ASCII characters (0x00-0x7F)
  - Handles 2-byte characters (0x80-0x7FF)
  - Handles 3-byte characters (0x800-0xFFFF)
  - Handles 4-byte characters (0x10000-0x10FFFF) including emojis

### 🧪 Test Coverage

Added comprehensive test cases covering:
- Basic ASCII string conversions
- Unicode character conversions (accented characters)
- Emoji conversions (4-byte UTF-8)
- Bidirectional conversion verification
- Chain conversion validation

All tests pass successfully with the new implementation.

### 🔧 Implementation Details

- **Template specializations**: Following the existing code pattern and avoiding large function modifications as suggested in the issue comments
- **Memory efficient**: Direct reinterpretation for `std::string` ↔ `std::u8string` conversions
- **Standards compliant**: Proper UTF-8 encoding implementation for multi-byte sequences
- **Chain pattern**: Reuses conversion logic for maintainability

### 📋 Supported Conversions

| Source | Target | Method |
|--------|--------|--------|
| `std::u8string` | `std::string` | Direct memory reinterpretation |
| `std::string` | `std::u8string` | Direct memory reinterpretation |
| `std::u16string` | `std::u8string` | UTF-8 encoding |
| `std::u32string` | `std::u8string` | UTF-8 encoding |
| `std::u16string` | `std::string` | Chain: u16 → u8 → string |
| `std::u32string` | `std::string` | Chain: u32 → u8 → string |

### ⚠️ Requirements

As specified in the issue, these conversions work correctly only when `std::string` is configured to use UTF-8 encoding by the compiler.

---

Fixes #76

🤖 Generated with [Claude Code](https://claude.ai/code)