### PR TITLE
Implement explicit ToString methods for converter classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Converters/issues/73
+Your prepared branch: issue-73-88c2b6f2
+Your prepared working directory: /tmp/gh-issue-solver-1757746528778
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Converters/issues/73
-Your prepared branch: issue-73-88c2b6f2
-Your prepared working directory: /tmp/gh-issue-solver-1757746528778
-
-Proceed.

--- a/csharp/Platform.Converters.Tests/ConverterTests.cs
+++ b/csharp/Platform.Converters.Tests/ConverterTests.cs
@@ -52,5 +52,31 @@ namespace Platform.Converters.Tests
             TestObjectConversion(true);
         }
         private static void TestObjectConversion<T>(T value) => Assert.Equal(value, UncheckedConverter<object, T>.Default.Convert(value));
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            var uncheckedConverter = UncheckedConverter<int, ulong>.Default;
+            var checkedConverter = CheckedConverter<int, ulong>.Default;
+            var signExtendingConverter = UncheckedSignExtendingConverter<byte, long>.Default;
+            var cachingDecorator = new CachingConverterDecorator<int, ulong>(uncheckedConverter);
+            
+            Assert.Contains("UncheckedConverter", uncheckedConverter.ToString());
+            Assert.Contains("Int32", uncheckedConverter.ToString());
+            Assert.Contains("UInt64", uncheckedConverter.ToString());
+            
+            Assert.Contains("CheckedConverter", checkedConverter.ToString());
+            Assert.Contains("Int32", checkedConverter.ToString());
+            Assert.Contains("UInt64", checkedConverter.ToString());
+            
+            Assert.Contains("UncheckedSignExtendingConverter", signExtendingConverter.ToString());
+            Assert.Contains("Byte", signExtendingConverter.ToString());
+            Assert.Contains("Int64", signExtendingConverter.ToString());
+            
+            Assert.Contains("CachingConverterDecorator", cachingDecorator.ToString());
+            Assert.Contains("Int32", cachingDecorator.ToString());
+            Assert.Contains("UInt64", cachingDecorator.ToString());
+            Assert.Contains("UncheckedConverter", cachingDecorator.ToString());
+        }
     }
 }

--- a/csharp/Platform.Converters/CachingConverterDecorator.cs
+++ b/csharp/Platform.Converters/CachingConverterDecorator.cs
@@ -64,5 +64,13 @@ namespace Platform.Converters
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TTarget Convert(TSource source) => _cache.GetOrAdd(source, _baseConverter.Convert);
+
+        /// <summary>
+        /// <para>Returns a string that represents the current caching converter decorator.</para>
+        /// <para>Возвращает строку, представляющую текущий декоратор кэширующего конвертера.</para>
+        /// </summary>
+        /// <returns><para>A string that represents the current caching converter decorator.</para><para>Строка, представляющая текущий декоратор кэширующего конвертера.</para></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override string ToString() => $"{GetType().Name}<{typeof(TSource).Name}, {typeof(TTarget).Name}>({_baseConverter})";
     }
 }

--- a/csharp/Platform.Converters/ConverterBase.cs
+++ b/csharp/Platform.Converters/ConverterBase.cs
@@ -26,6 +26,14 @@ namespace Platform.Converters
         public abstract TTarget Convert(TSource source);
         
         /// <summary>
+        /// <para>Returns a string that represents the current converter.</para>
+        /// <para>Возвращает строку, представляющую текущий конвертер.</para>
+        /// </summary>
+        /// <returns><para>A string that represents the current converter.</para><para>Строка, представляющая текущий конвертер.</para></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override string ToString() => $"{GetType().BaseType?.Name ?? GetType().Name}<{typeof(TSource).Name}, {typeof(TTarget).Name}>";
+        
+        /// <summary>
         /// <para>Generates a sequence of instructions using <see cref="ILGenerator"/> that converts a value of type <see cref="System.Object"/> to a value of type <typeparamref name="TTarget"/>.</para>
         /// <para>Генерирует последовательность инструкций при помощи <see cref="ILGenerator"/> выполняющую преобразование значения типа <see cref="System.Object"/> к значению типа <typeparamref name="TTarget"/>.</para>
         /// </summary>


### PR DESCRIPTION
## Summary

This pull request implements explicit `ToString()` methods for converter classes as requested in issue #73.

### Changes Made

- **ConverterBase<TSource, TTarget>**: Added `ToString()` method that returns the converter type name with generic type parameters (e.g., `UncheckedConverter<Int32, UInt64>`)
- **CachingConverterDecorator<TSource, TTarget>**: Added `ToString()` method that includes the base converter information (e.g., `CachingConverterDecorator<Int32, UInt64>(UncheckedConverter<Int32, UInt64>)`)
- **Comprehensive Tests**: Added test cases to verify `ToString()` functionality across all converter types

### Technical Details

- The `ToString()` implementation uses `GetType().BaseType?.Name ?? GetType().Name` to handle dynamically generated converter classes that have auto-generated type names
- For `CachingConverterDecorator`, the implementation includes the wrapped base converter's string representation
- All methods are marked with `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for performance consistency with the codebase
- Documentation follows the project's bilingual pattern (English and Russian)

### Test Results

All existing tests continue to pass, and new tests verify the `ToString()` functionality:

```
Passed!  - Failed:     0, Passed:     5, Skipped:     0, Total:     5
```

### Use Case

These `ToString()` implementations will be useful for:
- Debugging and logging converter instances
- The Platform.Collections.Walkers `CreateSegment` method mentioned in the issue
- General diagnostics and troubleshooting

Fixes #73

---

🤖 Generated with [Claude Code](https://claude.ai/code)